### PR TITLE
change TreeAlign to tree_align, and add data_dir test fixture

### DIFF
--- a/src/dbga/utils.py
+++ b/src/dbga/utils.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple, Set, Union
 
 from cogent3.align import global_pairwise
-from cogent3.align.progressive import TreeAlign
+from cogent3.align.progressive import tree_align
 from cogent3.core.sequence import DnaSequence
 from cogent3.evolve.fast_distance import DistanceMatrix
 from cogent3.maths.stats.number import CategoryCounter
@@ -228,7 +228,7 @@ def dna_msa(
         else:
             tree = dm.quick_tree()
 
-        aln, _ = TreeAlign(
+        aln, _ = tree_align(
             model=model,
             seqs=seqs_not_null,
             tree=tree,
@@ -250,7 +250,7 @@ def dna_msa(
             dm_subset = dm.take_dists(seqs_not_null.names)
             tree = dm_subset.quick_tree()
 
-        aln, _ = TreeAlign(
+        aln, _ = tree_align(
             model=model,
             seqs=seqs_not_null,
             tree=tree,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import pytest
+
+@pytest.fixture
+def data_dir():
+    # returns the path to the data directory
+    return os.path.join(os.path.dirname(__file__), 'data')

--- a/tests/test_adaptive_debruijn.py
+++ b/tests/test_adaptive_debruijn.py
@@ -1,3 +1,4 @@
+import os
 from cogent3 import load_unaligned_seqs
 from cogent3.align import make_dna_scoring_dict
 from dbga.adaptive_debruijn import adpt_dbg_alignment_recursive
@@ -15,33 +16,33 @@ def adaptive_dbg_alignment_checker(file, k_choice, aln_str_res):
         input, k_index=0, k_choice=k_choice, s=s, d=10, e=2) == aln_str_res
 
 
-def test_adpt_dbg_alignment_recursive_1():
+def test_adpt_dbg_alignment_recursive_1(data_dir):
     # simple test on adaptive de Bruijn alignment
-    file = "data/gap_bubble_duplicate.fasta"
+    file = os.path.join(data_dir,"gap_bubble_duplicate.fasta")
     k_choice = (3, 2)
     aln_str_res = ("GTACACGTATG", "GTACACG-ATG")
     adaptive_dbg_alignment_checker(file, k_choice, aln_str_res)
 
 
-def test_adpt_dbg_alignment_recursive_2():
+def test_adpt_dbg_alignment_recursive_2(data_dir):
     # test case to see whether the algorithm can filter invalid k choices
-    file = "data/gap_bubble_duplicate.fasta"
+    file = os.path.join(data_dir,"gap_bubble_duplicate.fasta")
     k_choice = (7, 5, 3, 2)
     aln_str_res = ("GTACACGTATG", "GTACACG-ATG")
     adaptive_dbg_alignment_checker(file, k_choice, aln_str_res)
 
 
-def test_adpt_dbg_alignment_recursive_3():
+def test_adpt_dbg_alignment_recursive_3(data_dir):
     # test case when restricting 
-    file = "data/duplicate_unbalanced_end.fasta"
+    file = os.path.join(data_dir,"duplicate_unbalanced_end.fasta")
     k_choice = (3,)
     aln_str_res = ("TGTACGTCAATGTCG", "TGTAAGTCAATG---")
     adaptive_dbg_alignment_checker(file, k_choice, aln_str_res)
 
 
-def test_adpt_dbg_alignment_recursive_4():
+def test_adpt_dbg_alignment_recursive_4(data_dir):
     # test case where the duplicate k-mers exists in the stem
-    file = "data/duplicate_in_stem.fasta"
+    file = os.path.join(data_dir,"duplicate_in_stem.fasta")
     k_choice = (3,)
     aln_str_res = ("GTACACGTATG", "GTACTCGTATG")
     adaptive_dbg_alignment_checker(file, k_choice ,aln_str_res)

--- a/tests/test_debruijn_msa.py
+++ b/tests/test_debruijn_msa.py
@@ -1,3 +1,4 @@
+import os
 from dbga.debruijn_msa import *
 import pytest
 
@@ -33,12 +34,12 @@ def msa_three_seqs_checker(seqs, k, exp_seqs_idx, exp_merge, exp_aln):
     assert db.merge_node_idx == exp_merge
 
 
-def test_msa_example1():
+def test_msa_example1(data_dir):
     seq1 = "ACTTGACAGCT"
     seq2 = "ACATGACAGCT"
     seq3 = "ACTTGACACGT"
     msa_three_seqs_checker(
-        seqs="data/msa_example1.fasta",
+        seqs= os.path.join(data_dir,"msa_example1.fasta"),
         k=3,
         exp_seqs_idx=[
             list(range(10)),
@@ -50,12 +51,12 @@ def test_msa_example1():
     )
 
 
-def test_msa_example2_not_optimal():
+def test_msa_example2_not_optimal(data_dir):
     seq1 = "GTAATTGCCACGCGA--"
     seq2 = "GTAATTGCCT--CGAGA"
     seq3 = "GTAATTGCCACGCGA--"
     msa_three_seqs_checker(
-        seqs="data/msa_example2.fasta",
+        seqs=os.path.join(data_dir,"msa_example2.fasta"),
         k=3,
         exp_seqs_idx=[
             list(range(15)),
@@ -67,12 +68,12 @@ def test_msa_example2_not_optimal():
     )
 
 
-def test_msa_example2_success():
+def test_msa_example2_success(data_dir):
     seq1 = "GTAATTGCCACGCGA"
     seq2 = "GTAATTGCCTCGAGA"
     seq3 = "GTAATTGCCACGCGA"
     msa_three_seqs_checker(
-        seqs="data/msa_example2.fasta",
+        seqs=os.path.join(data_dir,"msa_example2.fasta"),
         k=4,
         exp_seqs_idx=[
             list(range(14)),
@@ -84,21 +85,21 @@ def test_msa_example2_success():
     )
 
 
-def test_msa_example3_fail():
+def test_msa_example3_fail(data_dir):
     with pytest.raises(ValueError) as e:
-        DeBruijnMultiSeqs("data/msa_example3.fasta", k=3, moltype="dna")
+        DeBruijnMultiSeqs(os.path.join(data_dir,"msa_example3.fasta"), k=3, moltype="dna")
         assert (
             e.value
             == "Cycles detected in de Bruijn graph, usually caused by small kmer sizes"
         )
 
 
-def test_msa_example3_success():
+def test_msa_example3_success(data_dir):
     seq1 = "TACCGTCCAGACGTAAT"
     seq2 = "TACGGTCCAGACCTAAT"
     seq3 = "TACGGTCCAGACCTAAT"
     msa_three_seqs_checker(
-        seqs="data/msa_example3.fasta",
+        seqs=os.path.join(data_dir,"msa_example3.fasta"),
         k=4,
         exp_seqs_idx=[
             list(range(16)),
@@ -110,12 +111,12 @@ def test_msa_example3_success():
     )
 
 
-def test_msa_example4():
+def test_msa_example4(data_dir):
     seq1 = "GTACAAGCGATG"
     seq2 = "GTACAAGCGA--"
     seq3 = "GTAC-AGCGATG"
     msa_three_seqs_checker(
-        seqs="data/msa_example4.fasta",
+        seqs=os.path.join(data_dir,"msa_example4.fasta"),
         k=3,
         exp_seqs_idx=[
             list(range(12)),
@@ -127,12 +128,12 @@ def test_msa_example4():
     )
 
 
-def test_msa_example5():
+def test_msa_example5(data_dir):
     seq1 = "GTACACGCG"
     seq2 = "GTACA-GCG"
     seq3 = "GTACAAGCG"
     msa_three_seqs_checker(
-        seqs="data/msa_example5.fasta",
+        seqs=os.path.join(data_dir,"msa_example5.fasta"),
         k=3,
         exp_seqs_idx=[
             list(range(9)),

--- a/tests/test_debruijn_pairwise.py
+++ b/tests/test_debruijn_pairwise.py
@@ -1,3 +1,4 @@
+import os
 from dbga.debruijn_pairwise import *
 import pytest
 
@@ -46,12 +47,12 @@ def example_checker(seqs, k, exp_seq1_idx, exp_seq2_idx, exp_merge, exp_aln):
     assert db.merge_node_idx == exp_merge
 
 
-def test_substitution_middle():
+def test_substitution_middle(data_dir):
     # NOTE: Basic substitution test
     seq1 = "GTACAAGCGA"
     seq2 = "GTACACGCGA"
     example_checker(
-        seqs="data/substitution_middle.fasta",
+        seqs=os.path.join(data_dir,"substitution_middle.fasta"),
         k=3,
         exp_seq1_idx=list(range(10)),
         exp_seq2_idx=[10, 1, 2, 3, 11, 12, 13, 7, 8, 14],
@@ -60,12 +61,12 @@ def test_substitution_middle():
     )
 
 
-def test_gap_bubble_duplicate():
+def test_gap_bubble_duplicate(data_dir):
     # NOTE: Bubble in the middle (gap) test, with duplicate kmers
     seq1 = "GTACACGTATG"
     seq2 = "GTACACG-ATG"
     example_checker(
-        seqs="data/gap_bubble_duplicate.fasta",
+        seqs=os.path.join(data_dir,"gap_bubble_duplicate.fasta"),
         k=3,
         exp_seq1_idx=list(range(9)),
         exp_seq2_idx=[9, 1, 2, 3, 4, 10, 11, 7, 12],
@@ -74,12 +75,12 @@ def test_gap_bubble_duplicate():
     )
 
 
-def test_gap_at_end():
+def test_gap_at_end(data_dir):
     # NOTE: Gaps at unbalanced ends of sequences
     seq1 = "GTACAAGCGATG"
     seq2 = "GTACAAGCGA--"
     example_checker(
-        seqs="data/gap_at_end.fasta",
+        seqs=os.path.join(data_dir,"gap_at_end.fasta"),
         k=3,
         exp_seq1_idx=list(range(12)),
         exp_seq2_idx=[12, 1, 2, 3, 4, 5, 6, 7, 8, 13],
@@ -88,12 +89,12 @@ def test_gap_at_end():
     )
 
 
-def test_gap_at_start():
+def test_gap_at_start(data_dir):
     # NOTE: Gaps at unbalanced starts of sequences
     seq1 = "TGTACAAGCGA"
     seq2 = "-GTACAAGCGA"
     example_checker(
-        seqs="data/gap_at_start.fasta",
+        seqs=os.path.join(data_dir,"gap_at_start.fasta"),
         k=3,
         exp_seq1_idx=list(range(11)),
         exp_seq2_idx=[11, 2, 3, 4, 5, 6, 7, 8, 9, 12],
@@ -102,12 +103,12 @@ def test_gap_at_start():
     )
 
 
-def test_bubble_consecutive_duplicate():
+def test_bubble_consecutive_duplicate(data_dir):
     # NOTE: Subtitution in the middle. Two duplicate kmers (consecutive)
     seq1 = "TGTACTGTAGA"
     seq2 = "TGTACTATAGA"
     example_checker(
-        seqs="data/bubble_consecutive_duplicate.fasta",
+        seqs=os.path.join(data_dir,"bubble_consecutive_duplicate.fasta"),
         k=3,
         exp_seq1_idx=list(range(7)),
         exp_seq2_idx=[7, 1, 2, 8, 9, 10, 4, 5, 11],
@@ -116,12 +117,12 @@ def test_bubble_consecutive_duplicate():
     )
 
 
-def test_duplicate_unbalanced_end():
+def test_duplicate_unbalanced_end(data_dir):
     # NOTE: Very comprehensive test, duplicate kmers (anywhere, even after merge node), unbalanced ends
     seq1 = "TGTACGTCAATGTCG"
     seq2 = "TGTAAGTCAATG---"
     example_checker(
-        seqs="data/duplicate_unbalanced_end.fasta",
+        seqs=os.path.join(data_dir,"duplicate_unbalanced_end.fasta"),
         k=3,
         exp_seq1_idx=list(range(11)),
         exp_seq2_idx=[11, 1, 12, 13, 14, 5, 6, 7, 8, 15],
@@ -130,13 +131,13 @@ def test_duplicate_unbalanced_end():
     )
 
 
-def test_unbalanced_end_w_duplicate():
+def test_unbalanced_end_w_duplicate(data_dir):
     # NOTE: Very comprehensive test, duplicate kmers (anywhere, even after merge node), unbalanced ends
     #       Sequence end by duplicate kmer
     seq1 = "TGTACGTCAATGTCG"
     seq2 = "TGTAAGTCAATGT--"
     example_checker(
-        seqs="data/unbalanced_end_w_duplicate.fasta",
+        seqs=os.path.join(data_dir,"unbalanced_end_w_duplicate.fasta"),
         k=3,
         exp_seq1_idx=list(range(11)),
         exp_seq2_idx=[11, 1, 12, 13, 14, 5, 6, 7, 8, 15],
@@ -145,13 +146,13 @@ def test_unbalanced_end_w_duplicate():
     )
 
 
-def test_duplicate_kmer_in_bubble():
+def test_duplicate_kmer_in_bubble(data_dir):
     # NOTE: There are many duplicate kmers in this test case.
     #       They are all in the bubble of the de Bruijn graph
     seq1 = "TAC-ACGTAAT"
     seq2 = "TACGACG-AAT"
     example_checker(
-        seqs="data/duplicate_kmer_in_bubble.fasta",
+        seqs=os.path.join(data_dir,"duplicate_kmer_in_bubble.fasta"),
         k=3,
         exp_seq1_idx=list(range(9)),
         exp_seq2_idx=[9, 1, 10, 11, 7, 12],
@@ -160,13 +161,13 @@ def test_duplicate_kmer_in_bubble():
     )
 
 
-def test_both_end_duplicate():
+def test_both_end_duplicate(data_dir):
     # NOTE: Two sequences end with duplicate kmers, and these duplicate kmers are connected
     #       to a merge node.
     seq1 = "ACGTGACG"
     seq2 = "ACTTGACG"
     example_checker(
-        seqs="data/both_end_duplicate.fasta",
+        seqs=os.path.join(data_dir,"both_end_duplicate.fasta"),
         k=3,
         exp_seq1_idx=list(range(6)),
         exp_seq2_idx=[6, 7, 8, 9, 3, 4, 10],
@@ -175,12 +176,12 @@ def test_both_end_duplicate():
     )
 
 
-def test_unrelated_sequences():
+def test_unrelated_sequences(data_dir):
     # NOTE: Two sequences do not share any common kmer
     seq1 = "ACGT--AGTATC"
     seq2 = "ACCTACAGCA--"
     example_checker(
-        seqs="data/unrelated_sequences.fasta",
+        seqs=os.path.join(data_dir,"unrelated_sequences.fasta"),
         k=3,
         exp_seq1_idx=list(range(8)),
         exp_seq2_idx=list(range(8, 18)),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import os
 from cogent3.align import make_dna_scoring_dict
 from cogent3.core.alphabet import AlphabetError
 from cogent3 import SequenceCollection, make_aligned_seqs
@@ -36,9 +37,9 @@ def test_read_debruijn_edge_kmer():
         read_nucleotide_from_kmers(seq5, 2)
 
 
-def test_load_sequences():
+def test_load_sequences(data_dir):
     # given a path, load sequences
-    path = "data/gap_at_end.fasta"
+    path = os.path.join(data_dir,"gap_at_end.fasta")
     sequence_loader_checker(
         load_sequences(path, moltype="dna"), "GTACAAGCGATG", "GTACAAGCGA"
     )
@@ -214,7 +215,7 @@ def test_sop():
     assert pairs == exp_dict
 
 
-def test_dna_msa():
+def test_dna_msa(data_dir):
     input1 = make_unaligned_seqs(
         {
             "seq1": "",
@@ -236,7 +237,7 @@ def test_dna_msa():
     msa_checker(dna_msa(input2), {"seq1": "ACTG", "seq2": "CCTG", "seq3": "----"})
 
     input3 = load_unaligned_seqs(
-        "data/msa_example5.fasta",
+        os.path.join(data_dir,"msa_example5.fasta"),
         moltype="dna"
     )
     # the special case where alignment could generate ambiguity, use a different method for testing


### PR DESCRIPTION
Changed calls to the cogent3 function TreeAlign to tree_align as that function changed in the last release of cogent3.

Added a test fixture `data_dir` to retrieve the test data directory relative to the `conftest.py` testing configuration file's location.  This will make testing resilient to pytest being run in any parent directory.